### PR TITLE
Move buildStatement out of the object model

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ For example, the following code:
 var template = `MATCH (:${foo} {value: {value}})`;
 var substitutions = { 'foo': 'Baz'};
 var parameters = { 'value': 'bar' };
-var statement = neo4j.buildStatement(template, substitutions, parameters);
+var statement = Neo4j.buildStatement(template, substitutions, parameters);
 ```
 
 Will yield the following object for `statement`:
@@ -251,6 +251,10 @@ npm run-script functional-test
 The Docker instance can now be stopped and deleted if it's no longer needed.
 
 # Release Notes
+
+## v0.0.4
+
+   * [Fix] - `buildStatement` no longer needs Neo4J to be initialised
 
 ## v0.0.3
 

--- a/neo4j.js
+++ b/neo4j.js
@@ -128,7 +128,7 @@ Neo4j.prototype.query = function(statement, parameters, callback) {
 // var template = `MATCH (:${foo} {value: {value}})`;
 // var substitutions = { 'foo': 'Baz'};
 // var parameters = { 'value': 'bar' };
-// var statement = neo4j.buildStatement(template, substitutions, parameters);
+// var statement = Neo4j.buildStatement(template, substitutions, parameters);
 // ```
 //
 // Will yield the following object for `statement`:
@@ -140,7 +140,7 @@ Neo4j.prototype.query = function(statement, parameters, callback) {
 // }
 // ```
 
-Neo4j.prototype.buildStatement = function(template, substitutions, parameters) {
+function buildStatement(template, substitutions, parameters) {
     var statement = template;
 
     if (Array.isArray(template)) {
@@ -174,7 +174,7 @@ Neo4j.prototype.buildStatement = function(template, substitutions, parameters) {
     }
 
     return { 'statement': statement, 'parameters': parameters };
-};
+}
 
 // Identifiers in Neo4j follow the following basic rules:
 //
@@ -193,6 +193,7 @@ function escapeIdentifier(string) {
 }
 
 module.exports = Neo4j;
+module.exports.buildStatement = buildStatement;
 module.exports.escapeIdentifier = escapeIdentifier;
 
 // ## License

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rainbird-neo4j",
   "description": "Thin wrapper around the Neo4j REST interface",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "neo4j.js",
   "author": "Dom Davis <dom@rainbird.ai>",
   "license": "ISC",

--- a/test/neo4j.test.js
+++ b/test/neo4j.test.js
@@ -121,10 +121,8 @@ describe('Neo4j wrapper', function() {
 
     describe('when building a statement', function() {
 
-        var db = new Neo4j('http://localhost:7474');
-
         it('should work with just a template defined', function(done) {
-            var statement = db.buildStatement('MATCH (n) RETURN n');
+            var statement = Neo4j.buildStatement('MATCH (n) RETURN n');
 
             expect(statement).to.have.property('statement',
                 'MATCH (n) RETURN n');
@@ -135,7 +133,7 @@ describe('Neo4j wrapper', function() {
         });
 
         it('should handle statements as arrays', function(done) {
-            var statement = db.buildStatement(['MATCH (n)', 'RETURN n']);
+            var statement = Neo4j.buildStatement(['MATCH (n)', 'RETURN n']);
 
             expect(statement).to.have.property('statement',
                 'MATCH (n)\nRETURN n');
@@ -146,7 +144,7 @@ describe('Neo4j wrapper', function() {
         });
 
         it('should perform any given substitutions', function(done) {
-            var statement = db.buildStatement('MATCH (${x}) RETURN ${x}',
+            var statement = Neo4j.buildStatement('MATCH (${x}) RETURN ${x}',
                 { 'x': 'n' });
 
             expect(statement).to.have.property('statement',
@@ -158,7 +156,7 @@ describe('Neo4j wrapper', function() {
         });
 
         it('should ignore extra definitions of substitutions', function(done) {
-            var statement = db.buildStatement('MATCH (${x}) RETURN ${x}',
+            var statement = Neo4j.buildStatement('MATCH (${x}) RETURN ${x}',
                 { 'x': 'n', 'y': 'z' });
 
             expect(statement).to.have.property('statement',
@@ -171,20 +169,20 @@ describe('Neo4j wrapper', function() {
 
         it('should error if an undefined substitution is used', function(done) {
             expect(function() {
-                db.buildStatement('MATCH (${x}) RETURN n');
+                Neo4j.buildStatement('MATCH (${x}) RETURN n');
             }).to.throw(Error);
             done();
         });
 
         it('should error if undefined substitutions are used', function(done) {
             expect(function() {
-                db.buildStatement('MATCH (${x}) RETURN ${y}');
+                Neo4j.buildStatement('MATCH (${x}) RETURN ${y}');
             }).to.throw(Error);
             done();
         });
 
         it('should add parameter object', function(done) {
-            var statement = db.buildStatement(
+            var statement = Neo4j.buildStatement(
                 'MATCH (n {value: {value}) RETURN n', {}, { 'value': 'foo' });
 
             expect(statement).to.have.property('statement',


### PR DESCRIPTION
We don't need a Neo4j object to build a statement