### PR TITLE
Handle no body

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,9 @@ The Docker instance can now be stopped and deleted if it's no longer needed.
 
 # Release Notes
 
+## v0.2.2
+  *  [Fix] Handle the case when a response is parsed without a body.
+
 ## v0.2.1
   * [Misc] Add warning about substitutions and injection attacks.
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ The Docker instance can now be stopped and deleted if it's no longer needed.
 
 ## v0.2.2
   *  [Fix] Handle the case when a response is parsed without a body.
+  *  [Fix] Neo4j URLs can now have trailing slashes
 
 ## v0.2.1
   * [Misc] Add warning about substitutions and injection attacks.

--- a/neo4j.js
+++ b/neo4j.js
@@ -53,6 +53,10 @@ function parseResults(err, results, info, callback) {
         return callback(err, [], info);
     }
 
+    if (!results.body) {
+        return callback(new Error('No body in results'), [], info);
+    }
+
     if (results.body.transaction) {
         info.timeout = results.body.transaction.expires;
     }

--- a/neo4j.js
+++ b/neo4j.js
@@ -9,7 +9,13 @@ var regexp = /.*\/db\/data\/transaction\/(\d+)\/commit.*/;
 // lines of `http://localhost:7474`.
 
 function Neo4j(uri) {
-    this.neo4j = uri + '/db/data/transaction/';
+    var path = 'db/data/transaction/';
+
+    if(uri.substr(-1) === "/" ) {
+        this.neo4j = uri + path;
+    } else {
+        this.neo4j = uri + '/' + path;
+    }
 }
 
 // Results from the Neo4j REST API aren't in the best format and the

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rainbird-neo4j",
   "description": "Thin wrapper around the Neo4j REST interface",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "neo4j.js",
   "author": "Dom Davis <dom@rainbird.ai>",
   "license": "ISC",

--- a/test/neo4j.test.js
+++ b/test/neo4j.test.js
@@ -262,4 +262,16 @@ describe('Neo4j wrapper', function() {
             });
         });
     });
+
+    describe('When parsing results', function() {
+        it('should handle no body', function(done) {
+            var parse = Neo4j.__get__('parseResults');
+            parse(null, {}, 'info', function(err, results, info) {
+                expect(err).to.be.ok();
+                expect(results).to.be.empty();
+                expect(info).to.equal('info');
+                done();
+            });
+        });
+    });
 });

--- a/test/neo4j.test.js
+++ b/test/neo4j.test.js
@@ -4,6 +4,22 @@ var rewire = require('rewire');
 var Neo4j = rewire('../neo4j.js');
 
 describe('Neo4j wrapper', function() {
+    describe('when initialising', function() {
+        it('should allow a trailing /', function(done) {
+            var neo4j = new Neo4j('http://localhost:7474/');
+            var uri = neo4j.neo4j;
+            expect(uri).to.equal('http://localhost:7474/db/data/transaction/');
+            done();
+        });
+
+        it('should allow no trailing /', function(done) {
+            var neo4j = new Neo4j('http://localhost:7474');
+            var uri = neo4j.neo4j;
+            expect(uri).to.equal('http://localhost:7474/db/data/transaction/');
+            done();
+        });
+    });
+
     describe('when building a statement', function() {
 
         it('should work with just a template defined', function(done) {
@@ -263,7 +279,7 @@ describe('Neo4j wrapper', function() {
         });
     });
 
-    describe('When parsing results', function() {
+    describe('when parsing results', function() {
         it('should handle no body', function(done) {
             var parse = Neo4j.__get__('parseResults');
             parse(null, {}, 'info', function(err, results, info) {


### PR DESCRIPTION
It's possible to have no body returned when parsing results. This is usually due to a complete cockup in the URL being called (for example undefined transaction ID). 